### PR TITLE
allow extensions to be lambdas

### DIFF
--- a/lib/rack/lti/config.rb
+++ b/lib/rack/lti/config.rb
@@ -36,7 +36,7 @@ module Rack::LTI
     end
 
     def to_xml(request, options = {})
-      options.merge! get_extensions(request)
+      options = options.merge(get_extensions(request))
 
       # Stringify keys for IMS::LTI
       config = self.merge(options).inject({}) do |h, v|

--- a/lib/rack/lti/config.rb
+++ b/lib/rack/lti/config.rb
@@ -35,7 +35,9 @@ module Rack::LTI
       self[:consumer_key].nil? && self[:consumer_secret].nil?
     end
 
-    def to_xml(options = {})
+    def to_xml(request, options = {})
+      options.merge! get_extensions(request)
+
       # Stringify keys for IMS::LTI
       config = self.merge(options).inject({}) do |h, v|
         h[v[0].to_s] = v[1]
@@ -53,6 +55,17 @@ module Rack::LTI
       else
         super
       end
+    end
+
+    private
+
+    def get_extensions(request)
+      return {} unless self.key? :extensions
+      extensions = self[:extensions].inject({}) do |h, (k, v)|
+        h[k] = v.respond_to?(:call) ? v.call(request) : v
+        h
+      end
+      { extensions: extensions }
     end
   end
 end

--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -32,7 +32,8 @@ module Rack::LTI
     private
 
     def config_action(request, env)
-      response = [@config.to_xml(launch_url: request.url.sub(@config.config_path, @config.launch_path))]
+      launch_url = request.url.sub(@config.config_path, @config.launch_path)
+      response = [@config.to_xml(request, launch_url: launch_url)]
       [200, { 'Content-Type' => 'application/xml', 'Content-Length' => response[0].length.to_s }, response]
     end
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -107,7 +107,7 @@ class ConfigTest < Minitest::Test
   def test_to_xml_includes_extensions_with_lambdas
     rack_request_stub = Struct.new(:base_url).new('rack-url.com')
     @config[:extensions] = {
-      'canvas.instructure.com' => -> (req) do
+      'canvas.instructure.com' => ->(req) do
         {
           'editor_button' => {
             'size'     => '16x16',


### PR DESCRIPTION
this allows extensions to be set at request time, e.g. so an app that's pointed to by many domains has a chance to incorporate the domain of the request into its config.xml
