### PR TITLE
Pass request object to #consumer_key and #consumer_secret

### DIFF
--- a/lib/rack/lti/config.rb
+++ b/lib/rack/lti/config.rb
@@ -24,7 +24,9 @@ module Rack::LTI
     [:consumer_key, :consumer_secret, :nonce_validator].each do |method|
       define_method(method) do |*args|
         if self[method].respond_to?(:call)
-          self[method].call(*args)
+          # Only pass the arguments supported by this lambda
+          supported_args = args.take(self[method].parameters.length)
+          self[method].call(*supported_args)
         else
           self[method]
         end

--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -37,9 +37,23 @@ module Rack::LTI
       [200, { 'Content-Type' => 'application/xml', 'Content-Length' => response[0].length.to_s }, response]
     end
 
+    def consumer_key_wrapper(key, consumer_id, req)
+      @config.consumer_key(key, consumer_id, req)
+    rescue ArgumentError
+      # Maintain backwards compatibility with previous #consumer_key signature
+      @config.consumer_key(key, consumer_id)
+    end
+
+    def consumer_secret_wrapper(key, consumer_id, req)
+      @config.consumer_secret(key, consumer_id, req)
+    rescue ArgumentError
+      # Maintain backwards compatibility with previous #consumer_secret signature
+      @config.consumer_secret(key, consumer_id)
+    end
+
     def launch_action(request, env)
-      provider = IMS::LTI::ToolProvider.new(@config.consumer_key(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid')),
-                                            @config.consumer_secret(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid')),
+      provider = IMS::LTI::ToolProvider.new(consumer_key_wrapper(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid'), request),
+                                            consumer_secret_wrapper(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid'), request),
                                             request.params)
 
       if valid?(provider, request)

--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -38,17 +38,23 @@ module Rack::LTI
     end
 
     def consumer_key_wrapper(key, consumer_id, req)
-      @config.consumer_key(key, consumer_id, req)
-    rescue ArgumentError
-      # Maintain backwards compatibility with previous #consumer_key signature
-      @config.consumer_key(key, consumer_id)
+      case @config.consumer_key.parameters.length
+      when 2
+        # Maintain backwards compatibility with previous #consumer_key signature
+        @config.consumer_key(key, consumer_id)
+      when 3
+        @config.consumer_key(key, consumer_id, req)
+      end
     end
 
     def consumer_secret_wrapper(key, consumer_id, req)
-      @config.consumer_secret(key, consumer_id, req)
-    rescue ArgumentError
-      # Maintain backwards compatibility with previous #consumer_secret signature
-      @config.consumer_secret(key, consumer_id)
+      case @config.consumer_secret.parameters.length
+      when 2
+        # Maintain backwards compatibility with previous #consumer_secret signature
+        @config.consumer_secret(key, consumer_id)
+      when 3
+        @config.consumer_secret(key, consumer_id, req)
+      end
     end
 
     def launch_action(request, env)

--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -37,29 +37,9 @@ module Rack::LTI
       [200, { 'Content-Type' => 'application/xml', 'Content-Length' => response[0].length.to_s }, response]
     end
 
-    def consumer_key_wrapper(key, consumer_id, req)
-      case @config.consumer_key.parameters.length
-      when 2
-        # Maintain backwards compatibility with previous #consumer_key signature
-        @config.consumer_key(key, consumer_id)
-      when 3
-        @config.consumer_key(key, consumer_id, req)
-      end
-    end
-
-    def consumer_secret_wrapper(key, consumer_id, req)
-      case @config.consumer_secret.parameters.length
-      when 2
-        # Maintain backwards compatibility with previous #consumer_secret signature
-        @config.consumer_secret(key, consumer_id)
-      when 3
-        @config.consumer_secret(key, consumer_id, req)
-      end
-    end
-
     def launch_action(request, env)
-      provider = IMS::LTI::ToolProvider.new(consumer_key_wrapper(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid'), request),
-                                            consumer_secret_wrapper(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid'), request),
+      provider = IMS::LTI::ToolProvider.new(@config.consumer_key(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid'), request),
+                                            @config.consumer_secret(*request.params.values_at('oauth_consumer_key', 'tool_consumer_instance_guid'), request),
                                             request.params)
 
       if valid?(provider, request)


### PR DESCRIPTION
This is useful for if other aspects of the request are needed to verify
a key/secret pair, like the domain.
