### PR TITLE
invalidate future timestamps

### DIFF
--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -80,7 +80,9 @@ module Rack::LTI
       if @config.time_limit.nil?
         true
       else
-        (Time.now.to_i - @config.time_limit) <= timestamp
+        cur_time = Time.now.to_i
+        # reject a furture timestamp
+        timestamp <= cur_time && (cur_time - @config.time_limit) <= timestamp
       end
     end
   end


### PR DESCRIPTION
When an LTI request is crafted where the timestamp is into the future and sent to quiz_lti, quiz_allows the request.