### PR TITLE
invalidate future timestamps

### DIFF
--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -80,7 +80,9 @@ module Rack::LTI
       if @config.time_limit.nil?
         true
       else
-        (Time.now.to_i - @config.time_limit) <= timestamp
+        cur_time = Time.now.to_i
+        # reject a furture timestamp
+        timestamp <= cur_time && (cur_time - @config.time_limit) <= timestamp
       end
     end
   end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -90,6 +90,18 @@ class MiddlewareTest < Minitest::Test
     end
   end
 
+  def test_call_returns_403_on_furture_timestamp
+    @lti_app.config.nonce_validator = true
+    @lti_app.config.time_limit      = 30
+
+    @lti_app.stub(:valid_request?, true) do
+      env      = Rack::MockRequest.env_for('/lti/launch',
+                                           oauth_timestamp: Time.now + 2)
+      response = @lti_app.call(env)
+      assert_equal 403, response[0]
+    end
+  end
+
   def test_call_stores_launch_params_in_the_session
     @lti_app.stub(:valid_request?, true) do
       env = Rack::MockRequest.env_for('/lti/launch', method: 'post',


### PR DESCRIPTION
When an LTI request is crafted where the timestamp is into the future and sent to lti, lti shouldn't allow the request.

refs https://instructure.atlassian.net/browse/QUIZ-2000