### PR TITLE
Future time limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode
-  - rbx-19mode

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ class Application < Rails::Application
       request.session['launch_params'] = lti_params
       response.headers['X-Custom-Header'] = 'value'
     },
+
     time_limit: 60*60,
+    future_time_limit: 60,
 
     extensions: {
       'canvas.instructure.com' => {
@@ -83,7 +85,9 @@ class Application < Sinatra::Base
       request.session['launch_params'] = lti_params
       response.headers['X-Custom-Header'] = 'value'
     },
+
     time_limit: 60*60,
+    future_time_limit: 60
 
     extensions: {
       'canvas.instructure.com' => {
@@ -124,8 +128,10 @@ values are:
   * `description` The description of your LTI application.
   * `nonce_validator` A lambda used to validate the current request's nonce.
     It is passed the nonce to verify. If not provided, all nonces are allowed.
-  * `time_limit` The time limit, in seconds, to consider requests valid within.
-    If not passed, the default is 3600 seconds (one hour).
+  * `time_limit` The past time limit, inclusive and in seconds, to consider requests
+    valid within.  If not passed, the default is 3600 seconds (one hour).
+  * `future_time_limit` The future time limit, inclusive and in seconds, to consider
+    requests valid within.  If not passed, all future timestamps are accepted as valid.
   * `success` A lambda called on successful launch. It is passed the launch
     params as a hash, the Rack Request, and the Rack Response. Can be used to
     cache params for the current user, find the current user, etc. By default,

--- a/lib/rack/lti/config.rb
+++ b/lib/rack/lti/config.rb
@@ -13,6 +13,7 @@ module Rack::LTI
         req.session['launch_params'] = lti if req.env['rack.session']
       },
       time_limit:      60*60,
+      future_time_limit: nil,
       title:           'LTI App'
     }
 

--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -77,11 +77,15 @@ module Rack::LTI
     end
 
     def valid_timestamp?(timestamp)
-      if @config.time_limit.nil?
-        true
-      else
-        (Time.now.to_i - @config.time_limit) <= timestamp
-      end
+      now = Time.now.to_i
+
+      # timestamp too far into the past?
+      return false if (past = config.time_limit) && (now - past > timestamp)
+
+      # timestamp too far into the future?
+      return false if (future = config.future_time_limit) && (now + future < timestamp)
+
+      true
     end
   end
 end

--- a/lib/rack/lti/middleware.rb
+++ b/lib/rack/lti/middleware.rb
@@ -7,7 +7,7 @@ module Rack::LTI
     attr_reader :app, :config
 
     def initialize(app, options = {}, &block)
-      @app    = app 
+      @app    = app
       @config = Config.new(options, &block)
     end
 

--- a/lib/rack/lti/version.rb
+++ b/lib/rack/lti/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module LTI
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -32,6 +32,7 @@ class ConfigTest < Minitest::Test
     assert_equal '/lti/launch',         @config.launch_path
     assert_equal true,                  @config.nonce_validator
     assert_equal 3600,                  @config.time_limit
+    assert_equal nil,                   @config.future_time_limit
     assert_equal 'LTI App',             @config.title
     assert_equal true,                  @config.redirect
     assert_instance_of Proc,            @config.success

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -27,7 +27,7 @@ class MiddlewareTest < Minitest::Test
 	def test_routes_returns_the_recognized_routes
 		known_routes = { @lti_app.config.config_path => :config_action,
 			@lti_app.config.launch_path => :launch_action }
-		assert_equal known_routes, @lti_app.routes	
+		assert_equal known_routes, @lti_app.routes
 	end
 
 	def test_call_returns_a_valid_rack_response

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -81,10 +81,28 @@ class MiddlewareTest < Minitest::Test
   def test_call_returns_403_on_expired_timestamp
     @lti_app.config.nonce_validator = true
     @lti_app.config.time_limit      = 30
+    timestamp = (Time.now - 60*60).to_i
 
     @lti_app.stub(:valid_request?, true) do
-      env      = Rack::MockRequest.env_for('/lti/launch',
-                                           oauth_timestamp: Time.now - 60*60)
+      env = Rack::MockRequest.env_for(
+        '/lti/launch',
+        params: { oauth_timestamp: timestamp }
+      )
+      response = @lti_app.call(env)
+      assert_equal 403, response[0]
+    end
+  end
+
+  def test_call_returns_403_on_future_timestamp
+    @lti_app.config.nonce_validator   = true
+    @lti_app.config.future_time_limit = 30
+    timestamp = (Time.now + 60*60).to_i
+
+    @lti_app.stub(:valid_request?, true) do
+      env = Rack::MockRequest.env_for(
+        '/lti/launch',
+        params: { oauth_timestamp: timestamp }
+      )
       response = @lti_app.call(env)
       assert_equal 403, response[0]
     end


### PR DESCRIPTION
[The OAuth 1.0 specification has no language controlling timestamps marked into the future](https://oauth.net/core/1.0/#nonce).

That said, tool providers will often want to protect themselves against launches that purposefully manipulate timestamps to avoid the nonce validation.

This pull request provides an "opt-in" superset of OAuth 1.0 timestamp validation so that tool providers can allow some future timestamps within an inclusive future time limit, and reject others that fall outside that range.

Also includes a minor version bump for new backward compatible functionality